### PR TITLE
Add basic GitHub Pages site

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,7 @@
+---
+permalink: /404.html
+layout: default
+title: 404
+---
+<h1>404: Page not found</h1>
+<p>Sorry, the page you are looking for does not exist.</p>

--- a/README
+++ b/README
@@ -1,1 +1,13 @@
 # United Lexicons Project
+
+This repository contains lexical resources and a simple website built with [Jekyll](https://jekyllrb.com/) and deployed via GitHub Pages.
+
+## Local development
+
+If you have Jekyll installed, you can build the site locally:
+
+```sh
+jekyll serve
+```
+
+Then open `http://localhost:4000` in your browser.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+title: United Lexicons
+description: Multilingual lexical resources
+# Use a simple GitHub Pages-compatible theme
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>United Lexicons</title>
+</head>
+<body>
+  <h1>United Lexicons Project</h1>
+  <p>Welcome to United Lexicons! This website hosts our multilingual lexical data and resources.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple landing page and 404 page
- configure Jekyll with a remote theme
- document local development instructions

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdae293cdc8320a7b7b3b9e44fcfa2